### PR TITLE
Telephony: Get SIM card capacity count of SMS.

### DIFF
--- a/telephony/java/com/android/internal/telephony/ISms.aidl
+++ b/telephony/java/com/android/internal/telephony/ISms.aidl
@@ -329,4 +329,11 @@ interface ISms {
      * @see #isImsSmsSupported()
      */
     String getImsSmsFormat();
+
+    /**
+     * Get the capacity count of sms on Icc card.
+     *
+     * @return capacity of ICC
+     */
+    int getSmsCapacityOnIcc();
 }


### PR DESCRIPTION
will fix build error with android_frameworks_opt_telephony & android_frameworks_opt_telephony-msim

Add one API:
- getSmsCapacityOnIcc: get the capacity of stored SMS on ICC card.

CRs-Fixed: 645022
Change-Id: I8064d694d35c4200074a24ee4159d09ecb2a779c
